### PR TITLE
Documentation improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [21,22,23]
+        otp_version: [22,23,24]
         os: [ubuntu-latest]
 
     container:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ rel/example_project
 .rebar3
 _build/
 rebar3
+doc/*
+!doc/style.css
+!doc/overview.edoc

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -55,3 +55,12 @@ clean: clean_logs $(REBAR)
 dist-clean: clean
 	$(REBAR) $(REBAR_OPTS) clean -a
 	rm -f ./rebar3
+
+##
+## Doc targets
+##
+docs: $(REBAR)
+	$(REBAR) edoc
+
+edoc_private: $(REBAR)	
+	$(REBAR) as edoc_private edoc

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,0 +1,5 @@
+@author Zotonic Team
+@title dispatch_compiler
+@doc Compiles dispatch rules to an Erlang module for quick matching.
+@copyright Apache 2.0
+

--- a/doc/style.css
+++ b/doc/style.css
@@ -1,0 +1,71 @@
+/* standard EDoc style sheet */
+body {
+	font-family: Verdana, Arial, Helvetica, sans-serif;
+      	margin-left: .25in;
+       	margin-right: .2in;
+       	margin-top: 0.2in;
+       	margin-bottom: 0.2in;
+       	color: #000000;
+       	background-color: #ffffff;
+}
+h1,h2 {
+ 	margin-left: -0.2in;
+}
+div.navbar {
+	background-color: #add8e6;
+	padding: 0.2em;
+}
+h2.indextitle {
+	padding: 0.4em;
+	background-color: #add8e6;
+}
+h3.function,h3.typedecl {
+	background-color: #add8e6;
+ 	padding-left: 1em;
+}
+div.spec {
+ 	margin-left: 2em;
+	
+	background-color: #eeeeee;
+}
+a.module {
+	text-decoration:none
+}
+a.module:hover {
+	background-color: #eeeeee;
+}
+ul.definitions {
+	list-style-type: none;
+}
+ul.index {
+	list-style-type: none;
+	background-color: #eeeeee;
+}
+
+/*
+ * Minor style tweaks
+ */
+ul {
+	list-style-type: square;
+}
+table {
+	border-collapse: collapse;
+}
+td {
+	padding: 3px;
+	vertical-align: middle;
+}
+
+/*
+Tune styles
+*/
+
+table[summary="navigation bar"] {
+	background-image: url('http://zotonic.com/lib/images/logo.png');
+	background-repeat: no-repeat;
+	background-position: center;
+}
+
+code, p>tt, a>tt {
+	font-size: 1.2em;
+}

--- a/rebar.config
+++ b/rebar.config
@@ -21,3 +21,23 @@
     {dispatch_compiler, match, 3},
     {dispatch_compiler, runtime_bind, 3}
 ]}.
+
+{edoc_opts, [
+    {preprocess, true}, {stylesheet, "style.css"}
+]}.
+
+{profiles, [
+	{edoc_private, [
+		{edoc_opts, [
+			{private, true}
+		]}
+	]},
+	{test, [
+	    {dialyzer, [
+          {warnings, [
+              no_return
+          ]}
+        ]}
+
+    ]}
+]}.

--- a/test/dispatch_compiler_basic_SUITE.erl
+++ b/test/dispatch_compiler_basic_SUITE.erl
@@ -3,8 +3,10 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile(export_all).
-
+-export([suite/0, all/0, groups/0, init_per_suite/1,
+	end_per_suite/1, init_per_group/2, end_per_group/2,
+	simple_test/1, wildcard_test/1,	wildcard2_test/1,
+	re_test/1, re2_test/1, re3_test/1, mf_test/1, is_foo/2]).
 
 suite() ->
     [


### PR DESCRIPTION
- `dispatch_compiler.erl`
  - Replace unnesecarylly html Character Entity `&lt;` to `<<`.
  - Expanded the description of functions by `-spec` tag and EDoc tags.
  - Simplify -spec description.

- EDoc
  - Tune css stylesheet.

- GNUmakefile
  - Add documentation targets for generation public and private documenation.

- rebar.config
  - Add documentation generation and testing profiles.
  - Add option to generate public and private documentation.

- .gitignore
  - Add .gitignore option for generated documentation.

- test/dispatch_compiler_basic_SUITE.erl
  - Fix  "Warning: export_all"